### PR TITLE
Volunteer model

### DIFF
--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -1,0 +1,5 @@
+class Instrument < ApplicationRecord
+  has_many :volunteer_instruments
+  has_many :volunteers, through: :volunteer_instruments
+
+end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -1,5 +1,4 @@
 class Instrument < ApplicationRecord
   has_many :volunteer_instruments
   has_many :volunteers, through: :volunteer_instruments
-
 end

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -1,0 +1,26 @@
+class Volunteer < ApplicationRecord
+  has_many :volunteer_instruments
+  has_many :instruments, through: :volunteer_instruments
+
+  validates_presence_of :name, :role
+
+  enum :role, {basic: 0, leader: 1}
+
+  def singer?
+    music_roles.any?("vocals")
+  end
+
+  def only_singer?
+    music_roles.all?("vocals")
+  end
+
+  def only_instrumentalist?
+    music_roles.none?("vocals")
+  end
+
+  private
+
+  def music_roles
+    instruments.pluck(:name)
+  end
+end

--- a/app/models/volunteer_instrument.rb
+++ b/app/models/volunteer_instrument.rb
@@ -1,0 +1,4 @@
+class VolunteerInstrument < ApplicationRecord
+  belongs_to :instrument
+  belongs_to :volunteer
+end

--- a/db/migrate/20240301184804_create_volunteer.rb
+++ b/db/migrate/20240301184804_create_volunteer.rb
@@ -1,0 +1,10 @@
+class CreateVolunteer < ActiveRecord::Migration[7.0]
+  def change
+    create_table :volunteers do |t|
+      t.string :name
+      t.integer :role, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240301213654_create_instrument.rb
+++ b/db/migrate/20240301213654_create_instrument.rb
@@ -1,0 +1,9 @@
+class CreateInstrument < ActiveRecord::Migration[7.0]
+  def change
+    create_table :instruments do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240301214325_create_volunteer_instruments.rb
+++ b/db/migrate/20240301214325_create_volunteer_instruments.rb
@@ -1,0 +1,10 @@
+class CreateVolunteerInstruments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :volunteer_instruments do |t|
+      t.references :volunteer
+      t.references :instrument
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,39 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2024_03_01_214325) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "instruments", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "volunteer_instruments", force: :cascade do |t|
+    t.bigint "volunteer_id"
+    t.bigint "instrument_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["instrument_id"], name: "index_volunteer_instruments_on_instrument_id"
+    t.index ["volunteer_id"], name: "index_volunteer_instruments_on_volunteer_id"
+  end
+
+  create_table "volunteers", force: :cascade do |t|
+    t.string "name"
+    t.integer "role", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,19 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+Volunteer.create(name: "nick", role: 1)
+Volunteer.create(name: "lori", role: 1)
+Volunteer.create(name: "adam")
+Volunteer.create(name: "rachel")
+
+vocals = Instrument.create(name: "vocals")
+guitar = Instrument.create(name: "guitar")
+acoustic = Instrument.create(name: "acoustic")
+drums = Instrument.create(name: "drums")
+bass = Instrument.create(name: "bass")
+
+vocals.volunteers << Volunteer.find(1,2)
+guitar.volunteers << Volunteer.find(3)
+acoustic.volunteers << Volunteer.find(1)
+drums.volunteers << Volunteer.find(4)
+bass.volunteers << Volunteer.find(1)

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+describe Volunteer, type: :model do
+  describe "validations" do
+    it {should validate_presence_of(:name)}
+    it {should validate_presence_of(:role)}
+
+    let(:nick) { Volunteer.create(name: "nick", role: 1) }
+    let(:lori) { Volunteer.create(name: "lori", role: 1) }
+    let(:adam) { Volunteer.create(name: "adam", role: 0) }
+    let(:rachel) { Volunteer.create(name: "rachel", role: 0) }
+
+    let(:vocals) { Instrument.create(name: "vocals") }
+    let(:guitar) { Instrument.create(name: "guitar") }
+    let(:acoustic) { Instrument.create(name: "acoustic") }
+    let(:drums) { Instrument.create(name: "drums") }
+    let(:bass) { Instrument.create(name: "bass") }
+
+    before do
+      vocals.volunteers << [nick, lori]
+      guitar.volunteers << [adam]
+      acoustic.volunteers << [nick]
+      drums.volunteers << [rachel]
+      bass.volunteers << [nick]
+    end
+
+    describe "singer?" do
+      it "returns nick is a singer" do
+        expect(nick.singer?).to be true
+      end
+
+      it "returns adam and rachel are not singers" do
+        expect(adam.singer?).to be false
+        expect(rachel.singer?).to be false
+      end
+    end
+
+    describe "only_singer?" do
+      it "returns lori is only a singer" do
+        expect(lori.singer?).to be true
+        expect(lori.only_singer?).to be true
+      end
+
+      it "returns nick is not only a singer" do
+        expect(nick.singer?).to be true
+        expect(nick.only_singer?).to be false
+      end
+    end
+
+    describe "only instrumentalist" do
+      it "returns adam and rachel are only instrumentalists" do
+        expect(adam.only_instrumentalist?).to be true
+        expect(rachel.only_instrumentalist?).to be true
+      end
+
+      it "returns nick and lori are not only instrumentalists" do
+        expect(lori.only_instrumentalist?).to be false
+        expect(nick.only_instrumentalist?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Adds
- Volunteer Model and Spec
- Instrument Model
- VolunteerInstruments many to many association and model

## Cool Things
I added an enum for role in the Volunteer class.
```
class Volunteer < ApplicationRecord
 ...
  enum :role, {basic: 0, leader: 1}
...
end
```
Which meant I needed to add a default role of basic to all new Volunteers, unless otherwise specified.  The cool thing is that since we have this enum, we have some built in methods to check if someone is `basic` or a `leader`.

```
irb(main):001> nick = Volunteer.first
...
irb(main):002> nick.basic?
=> false
irb(main):003> nick.leader?
=> true
```

It is possible to add in `prefix: true` to the end of my enum setup.  This gives us the following behavior.
```
irb(main):002> nick.role_basic?
=> false
irb(main):003> nick.role_leader?
=> true
```
`suffix: true` gives us this.

```
irb(main):002> nick.basic_role?
=> false
irb(main):003> nick.leader_role?
=> true
```
## Reflections
I may end up changing some of the names of the methods I created for the Volunteer class.  I think it'll be valuable in the future to have access to some of these methods to build out a band with all of the necessary musicians/vocalists.

