### PR TITLE
Test instrument, clean up volunteer spec, add shoulda matchers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :development, :test do
   gem 'pry'
   gem 'active_designer'
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem 'shoulda-matchers'
 end
 
 group :development do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,5 +35,4 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_01_214325) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-
 end

--- a/spec/models/instrument_spec.rb
+++ b/spec/models/instrument_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+describe Volunteer, type: :model do
+  describe "validations" do
+    it { should validate_presence_of(:name) }
+  end
+end

--- a/spec/models/volunteer_spec.rb
+++ b/spec/models/volunteer_spec.rb
@@ -2,19 +2,21 @@ require "rails_helper"
 
 describe Volunteer, type: :model do
   describe "validations" do
-    it {should validate_presence_of(:name)}
-    it {should validate_presence_of(:role)}
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:role) }
+  end
 
-    let(:nick) { Volunteer.create(name: "nick", role: 1) }
-    let(:lori) { Volunteer.create(name: "lori", role: 1) }
-    let(:adam) { Volunteer.create(name: "adam", role: 0) }
-    let(:rachel) { Volunteer.create(name: "rachel", role: 0) }
+  describe "methods" do
+    let(:nick)     { Volunteer.create(name: "nick", role: 1) }
+    let(:lori)     { Volunteer.create(name: "lori", role: 1) }
+    let(:adam)     { Volunteer.create(name: "adam", role: 0) }
+    let(:rachel)   { Volunteer.create(name: "rachel", role: 0) }
 
-    let(:vocals) { Instrument.create(name: "vocals") }
-    let(:guitar) { Instrument.create(name: "guitar") }
+    let(:vocals)   { Instrument.create(name: "vocals") }
+    let(:guitar)   { Instrument.create(name: "guitar") }
     let(:acoustic) { Instrument.create(name: "acoustic") }
-    let(:drums) { Instrument.create(name: "drums") }
-    let(:bass) { Instrument.create(name: "bass") }
+    let(:drums)    { Instrument.create(name: "drums") }
+    let(:bass)     { Instrument.create(name: "bass") }
 
     before do
       vocals.volunteers << [nick, lori]


### PR DESCRIPTION
## Adds
- Instrument spec basic setup
- Shoulda matchers
- Cleanup musician spec to separate validations and method testing

## Cool Things
- [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers)
- Shoulda matchers are great for testing validations
- The main reason I like using shoulda is that it reads like english and feels like it fits the Ruby language nicely
- Example
```
class Volunteer < ApplciationRecord
  validates_presence_of :name, :role
end
```

```
describe Volunteer, type: :model do
  describe "validations" do
    it { should validate_presence_of(:name) }
    it { should validate_presence_of(:role) }
  end
end
```

See the difference? In the model it reads `validates_presence_of` where the test reads `should validate_presence_of`

## Reflections
I will probably add more methods to both of the existing classes.  The next PR will focus on add more api functionality to my app.  

