### PR TITLE
Api build instruments and volunteers

### DIFF
--- a/app/controllers/api/v1/instruments_controller.rb
+++ b/app/controllers/api/v1/instruments_controller.rb
@@ -1,0 +1,50 @@
+class Api::V1::InstrumentsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  # before_action :
+
+  def index
+    @instruments = Instrument.all
+    render json: @instruments
+  end
+
+  def show
+    @instrument = Instrument.find(params[:id])
+    render json: @instrument
+  end
+
+  def create
+    @instrument = Instrument.new(instrument_params)
+    if @instrument.save
+      render json: @instrument
+    else
+      render json: { error: 'unable to add instrument' }, status: 400
+    end
+  end
+
+  def update
+    begin
+      @instrument = Instrument.find(params[:id])
+      @instrument.update(instrument_params)
+      render json: { message: "Instrument updates"}, status: 200
+    rescue
+      render json: { error: "Unable to update instrument" }, status: 400
+    end
+  end
+
+  def destroy
+    begin
+      @instrument = Instrument.find(params[:id])
+      @instrument.destroy
+      render json: { message: "Instrument removed" }, status: 200
+    rescue ActiveRecord::RecordNotFound
+      render json: { message: "Error, instrument not removed" }, status: 400
+    end
+  end
+
+  private
+
+  def instrument_params
+    params.require(:instrument).permit(:name)
+  end
+
+end

--- a/app/controllers/api/v1/volunteers_controller.rb
+++ b/app/controllers/api/v1/volunteers_controller.rb
@@ -1,0 +1,53 @@
+class Api::V1::VolunteersController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def index
+    @volunteers = Volunteer.all
+    render json: @volunteers
+  end
+
+  def show
+    @volunteer = Volunteer.find(params[:id])
+    render json: @volunteer
+  end
+
+  def create
+    @volunteer = Volunteer.new(volunteer_params)
+    if @volunteer.save
+      render json: @volunteer
+    else
+      render json: { error: 'unable to add volunteer' }, status: 400
+    end
+  end
+
+  def update
+    begin
+      @volunteer = Volunteer.find(params[:id])
+      @volunteer.update(volunteer_params)
+      render json: { message: "Volunteer updates"}, status: 200
+    rescue
+      render json: { error: "Unable to update volunteer" }, status: 400
+    end
+  end
+
+  def destroy
+    begin
+      @volunteer = Volunteer.find(params[:id])
+      @volunteer.destroy
+      render json: { message: "Volunteer removed" }, status: 200
+    rescue ActiveRecord::RecordNotFound
+      render json: { message: "Error, volunteer not removed" }, status: 400
+    end
+  end
+
+  private
+
+  def find_volunteer
+    @volunteer = Volunteer.find(params[:id])
+  end
+
+  def volunteer_params
+    params.require(:volunteer).permit(:name)
+  end
+
+end

--- a/app/models/instrument.rb
+++ b/app/models/instrument.rb
@@ -1,4 +1,6 @@
 class Instrument < ApplicationRecord
   has_many :volunteer_instruments
   has_many :volunteers, through: :volunteer_instruments
+
+  validates_presence_of :name
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Defines the root path route ("/")
-  # root "articles#index"
+  namespace :api do
+    namespace :v1 do
+      resources :volunteers
+      resources :instruments
+    end
+  end
 end

--- a/spec/requests/api/v1/instruments_spec.rb
+++ b/spec/requests/api/v1/instruments_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Instruments", type: :request do
+  let!(:vocals)   { Instrument.create(name: "vocals") }
+  let!(:guitar)   { Instrument.create(name: "guitar") }
+  let!(:acoustic) { Instrument.create(name: "acoustic") }
+  let!(:drums)    { Instrument.create(name: "drums") }
+  let!(:bass)     { Instrument.create(name: "bass") }
+
+  describe "GET /index" do
+    it "returns success" do
+      get api_v1_instruments_path
+
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body).count).to eq(5)
+      expect(JSON.parse(response.body).first["name"]).to eq("vocals")
+      expect(JSON.parse(response.body).last["name"]).to eq("bass")
+    end
+  end
+
+  describe "GET /show" do
+    it "returns success" do
+      get api_v1_instrument_path(vocals.id)
+
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)["name"]).to eq("vocals")
+      expect(JSON.parse(response.body)["id"]).to eq(vocals.id)
+    end
+  end
+
+  describe "POST /create" do
+    it "returns success" do
+      post api_v1_instruments_path, params: { instrument: { name: "keytar" } }
+
+      expect(response).to have_http_status(200)
+      expect(JSON.parse(response.body)["name"]).to eq("keytar")
+    end
+
+    it "fails gracefully" do
+      post api_v1_instruments_path, params: { instrument: {name: nil} }
+
+      before_count = Instrument.count
+      expect(response).to have_http_status(400)
+      expect(JSON.parse(response.body)["error"]).to eq("unable to add instrument")
+      expect(Instrument.count).to eq(before_count)
+    end
+  end
+
+  describe "PATCH /update" do
+    it "returns success" do
+      put api_v1_instrument_path(guitar.id), params: { instrument: {name: "electric"} }
+
+      expect(response).to have_http_status(200)
+      expect(guitar.reload.name).to eq("electric")
+    end
+
+    it "fails gracefully" do
+      put api_v1_instrument_path(-1), params: { instrument: {name: nil} }
+
+      expect(response).to have_http_status(400)
+      expect(JSON.parse(response.body)["error"]).to eq("Unable to update instrument")
+    end
+  end
+
+  describe "DELETE /destroy" do
+    it "returns success" do
+      delete api_v1_instrument_path(vocals.id)
+
+      expect(response).to have_http_status(200)
+      expect(JSON.parse(response.body)["message"]).to eq("Instrument removed")
+      expect(Instrument.where(name: "vocals")).to eq([])
+    end
+
+    it "fails gracefully" do
+      delete api_v1_instrument_path(-1)
+
+      expect(response).to have_http_status(400)
+      expect(JSON.parse(response.body)["message"]).to eq("Error, instrument not removed")
+    end
+  end
+end

--- a/spec/requests/api/v1/volunteers_spec.rb
+++ b/spec/requests/api/v1/volunteers_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Volunteers", type: :request do
+  let!(:nick)   { Volunteer.create(name: "nick", role: 1) }
+  let!(:lori)   { Volunteer.create(name: "lori", role: 1) }
+  let!(:adam)   { Volunteer.create(name: "adam") }
+  let!(:rachel) { Volunteer.create(name: "rachel") }
+
+  describe "GET /index" do
+    it "returns success" do
+      get api_v1_volunteers_path
+
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body).count).to eq(4)
+      expect(JSON.parse(response.body).first["name"]).to eq("nick")
+      expect(JSON.parse(response.body).first["role"]).to eq("leader")
+      expect(JSON.parse(response.body).last["name"]).to eq("rachel")
+      expect(JSON.parse(response.body).last["role"]).to eq("basic")
+    end
+  end
+
+  describe "GET /show" do
+    it "returns success" do
+      get api_v1_volunteer_path(nick.id)
+
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)["name"]).to eq("nick")
+      expect(JSON.parse(response.body)["role"]).to eq("leader")
+      expect(JSON.parse(response.body)["id"]).to eq(nick.id)
+    end
+  end
+
+  describe "POST /create" do
+    it "returns success" do
+      post api_v1_volunteers_path, params: { volunteer: { name: "frank" } }
+
+      expect(response).to have_http_status(200)
+      expect(JSON.parse(response.body)["name"]).to eq("frank")
+    end
+
+    it "fails gracefully" do
+      post api_v1_volunteers_path, params: { volunteer: {name: nil} }
+
+      before_count = Volunteer.count
+      expect(response).to have_http_status(400)
+      expect(JSON.parse(response.body)["error"]).to eq("unable to add volunteer")
+      expect(Volunteer.count).to eq(before_count)
+    end
+  end
+
+  describe "PATCH /update" do
+    it "returns success" do
+      put api_v1_volunteer_path(nick.id), params: { volunteer: {name: "rad"} }
+
+      expect(response).to have_http_status(200)
+      expect(nick.reload.name).to eq("rad")
+    end
+
+    it "fails gracefully" do
+      put api_v1_volunteer_path(-1), params: { volunteer: {name: nil} }
+
+      expect(response).to have_http_status(400)
+      expect(JSON.parse(response.body)["error"]).to eq("Unable to update volunteer")
+    end
+  end
+
+  describe "DELETE /destroy" do
+    it "returns success" do
+      delete api_v1_volunteer_path(nick.id)
+
+      expect(response).to have_http_status(200)
+      expect(JSON.parse(response.body)["message"]).to eq("Volunteer removed")
+      expect(Instrument.where(name: "vocals")).to eq([])
+    end
+
+    it "fails gracefully" do
+      delete api_v1_volunteer_path(-1)
+
+      expect(response).to have_http_status(400)
+      expect(JSON.parse(response.body)["message"]).to eq("Error, volunteer not removed")
+    end
+  end
+end


### PR DESCRIPTION
## Adds
- Api endpoints for Volunteer and Instrument with full CRUD functionality
- Updates routes file

## Cool Things
- When it came to the create, update and destroy actions, I tested the happy/sad path for each.  
```
  describe "POST /create" do
    it "returns success" do
      post api_v1_instruments_path, params: { instrument: { name: "keytar" } }

      expect(response).to have_http_status(200)
      expect(JSON.parse(response.body)["name"]).to eq("keytar")
    end

    it "fails gracefully" do
      post api_v1_instruments_path, params: { instrument: {name: nil} }

      before_count = Instrument.count
      expect(response).to have_http_status(400)
      expect(JSON.parse(response.body)["error"]).to eq("unable to add instrument")
      expect(Instrument.count).to eq(before_count)
    end
  end
```

## Reflections
- It was really important to make sure I fully tested out my crud functionality.  I may end up adding more routes/actions as needed later but I like to start with the basic setup for a nice solid foundation. 
